### PR TITLE
Update TODO/FIXME color

### DIFF
--- a/src/main/resources/themes/Catppuccin.xml
+++ b/src/main/resources/themes/Catppuccin.xml
@@ -2817,9 +2817,9 @@
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="575268" />
+        <option name="FOREGROUND" value="fae3b0" />
         <option name="FONT_TYPE" value="2" />
-        <option name="ERROR_STRIPE_COLOR" value="fae3b0" />
+        <option name="ERROR_STRIPE_COLOR" value="f8bd96" />
       </value>
     </option>
     <option name="TS.MODULE_NAME">


### PR DESCRIPTION
Resolves #6

TODO and FIXME use the same style as far as I can tell (the screenshot doesn't show it, but I also tried FIXME)

![todo](https://user-images.githubusercontent.com/42128690/165988992-ae45a267-075d-49aa-8efc-3d8b7b8b62a9.png)
 