### PR TITLE
Updates for better XAML support

### DIFF
--- a/src/main/resources/themes/Catppuccin.theme.json
+++ b/src/main/resources/themes/Catppuccin.theme.json
@@ -33,7 +33,7 @@
     "secondaryBackground": "#302D41",
     "hoverBackground": "#575268",
     "selectionBackground": "#575268",
-    "selectionInactiveBackground": "#302D41",
+    "selectionInactiveBackground": "#1E1E2E",
     "borderColor": "#575268",
     "separatorColor": "#575268"
   },

--- a/src/main/resources/themes/Catppuccin.xml
+++ b/src/main/resources/themes/Catppuccin.xml
@@ -874,7 +874,11 @@
         <option name="FOREGROUND" value="f8bd96" />
       </value>
     </option>
-    <option name="DEFAULT_INSTANCE_FIELD" baseAttributes="DEFAULT_IDENTIFIER" />
+    <option name="DEFAULT_INSTANCE_FIELD">
+      <value>
+        <option name="FOREGROUND" value="d9e0ee" />
+      </value>
+    </option>
     <option name="DEFAULT_INTERFACE_NAME">
       <value>
         <option name="FOREGROUND" value="f8bd96" />
@@ -2501,6 +2505,11 @@
     <option name="ReSharper.BRACE_OUTLINE">
       <value>
         <option name="EFFECT_COLOR" value="d9e0ee" />
+      </value>
+    </option>
+    <option name="ReShaper.ENUM_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="89dceb" />
       </value>
     </option>
     <option name="ReSharper.FORMAT_STRING_ITEM">


### PR DESCRIPTION
This makes some minor changes to the language defaults for the Instance Field to change the color (actually to match what's in VSCode)

It also adds the ENUM_IDENTIFIER to change the Enum color from the same Orange color to the Light Blue color, which also matches what's in VSCode.

Rider doesn't actually have specific XAML support, so its still not *perfect* but this at least adds some color differentiation.

This fixes issue #8 

Here's a quick example:

![image](https://user-images.githubusercontent.com/39167186/173867134-54df2c77-e02d-4649-9922-18e3beb63222.png)
