### PR TITLE
Changes invalid character to match VSCode

### DIFF
--- a/src/main/resources/themes/Catppuccin.xml
+++ b/src/main/resources/themes/Catppuccin.xml
@@ -95,8 +95,8 @@
     </option>
     <option name="BAD_CHARACTER">
       <value>
-        <option name="FOREGROUND" value="1e1e2e" />
-        <option name="BACKGROUND" value="f28fad" />
+        <option name="FOREGROUND" value="d9e0ee" />
+        <option name="EFFECT_COLOR" value="f8bd96" />
         <option name="ERROR_STRIPE_COLOR" value="f28fad" />
       </value>
     </option>


### PR DESCRIPTION
The invalid character in the current theme has a very similar color to the background, thus unless the error background is active, the character is almost invisible. The error background would be fine, if it would reliably show up no matter what...

I've gone ahead and changed it so instead of using the red error, it follows the VSCode theme to make the invalid character very obvious no matter what (the below character is a different version of the semicolon, not the normal one):

<img width="238" alt="2022-06-22_08-49-18" src="https://user-images.githubusercontent.com/39167186/175046113-99daeee9-6ef1-4eb8-b9fe-3aca7e6c590e.png">

This fixes #12 