### PR TITLE
Fix tree row height

### DIFF
--- a/src/main/resources/themes/Catppuccin.theme.json
+++ b/src/main/resources/themes/Catppuccin.theme.json
@@ -301,6 +301,7 @@
       }
     },
     "Tree": {
+      "rowHeight": 24,
       "background": "black1",
       "modifiedItemForeground": "accentColor",
       "hoverBackground": "secondaryBackground",


### PR DESCRIPTION
Currently, on the [New JetBrains UI](https://blog.jetbrains.com/idea/2022/05/take-part-in-the-new-ui-preview-for-your-jetbrains-ide/) (and even a little bit on the old one), the rows in the file explorer are very tight, which is hard to read.

This PR proposes to raise the height to 24. In my opinion, it also looks pretty good on the old UI.

| Before this PR | After this PR |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/12123721/182162652-4c41170f-8d2b-4967-860f-cb29ed75cbdb.png) | ![after](https://user-images.githubusercontent.com/12123721/182162719-36436995-88b2-4025-a839-afca1566a582.png) |

| Default New UI | Old UI after this PR |
| --- | --- |
| ![Capture d’écran, le 2022-08-01 à 15 44 19](https://user-images.githubusercontent.com/12123721/182162856-03a0074b-c8ba-4875-9de5-535e621f62ba.png) | ![Capture d’écran, le 2022-08-01 à 15 48 25](https://user-images.githubusercontent.com/12123721/182163076-06a5ddae-dc5f-49f3-9b30-617ace27dd6b.png) |


 