### PR TITLE
fix: matched brace border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Matching braces now have a border when hovered.
+
 ### Deprecated
 
 ### Removed

--- a/generateFlavours/template.xml
+++ b/generateFlavours/template.xml
@@ -1831,6 +1831,7 @@
       <value>
         <option name="FOREGROUND" value="{{pink}}"/>
         <option name="FONT_TYPE" value="1"/>
+        <option name="EFFECT_COLOR" value="{{surface2}}" />
       </value>
     </option>
     <option name="MATCHED_TAG_NAME" baseAttributes="MATCHED_BRACE_ATTRIBUTES"/>


### PR DESCRIPTION
Using `surface2`, the same color as the keyword under caret border.

Before:
![2022-11-18_01-46](https://user-images.githubusercontent.com/79978224/202591238-779cbed3-ea2b-48be-913b-a89a30c27ae8.png)
After:
![2022-11-18_01-47](https://user-images.githubusercontent.com/79978224/202591241-d8e99170-853f-4289-b7ee-346f4d1689d8.png)
