### PR TITLE
feat: styling for new UI

### DIFF
--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -144,6 +144,7 @@ Object.entries(variants).forEach(([key, value]) => {
         borderColor: "accentColor",
       },
       Button: {
+        background: "mantle",
         foreground: "primaryForeground",
         startBorderColor: "secondaryBackground",
         endBorderColor: "secondaryBackground",
@@ -160,6 +161,9 @@ Object.entries(variants).forEach(([key, value]) => {
           focusColor: "accentColor",
           focusedBorderColor: "surface1",
         },
+      },
+      CheckBox: {
+        background: "mantle"
       },
       Counter: {
         foreground: "primaryBackground",
@@ -232,6 +236,9 @@ Object.entries(variants).forEach(([key, value]) => {
         visitedForeground: "secondaryAccentColor",
         pressedForeground: "secondaryAccentColor",
       },
+      MainToolbar: {
+        background: "mantle",
+      },
       NotificationsToolwindow: {
         newNotification: {
           background: "primaryBackground",
@@ -255,6 +262,9 @@ Object.entries(variants).forEach(([key, value]) => {
           informativeBackground: "primaryBackground",
           informativeBorderColor: "secondaryAccentColor",
         },
+      },
+      Panel: {
+        background: "mantle",
       },
       PasswordField: {
         background: "secondaryBackground",
@@ -302,6 +312,9 @@ Object.entries(variants).forEach(([key, value]) => {
           inactiveBackground: "secondaryBackground",
         },
       },
+      RadioButton: {
+        background: "mantle"
+      },
       ScrollBar: {
         Mac: {
           hoverThumbColor: "secondaryAccentColor",
@@ -328,6 +341,9 @@ Object.entries(variants).forEach(([key, value]) => {
       },
       SidePanel: {
         background: "mantle",
+      },
+      Spinner: {
+        background: "mantle"
       },
       StatusBar: {
         borderColor: "borderColor",
@@ -365,6 +381,7 @@ Object.entries(variants).forEach(([key, value]) => {
         borderHandleColor: "secondaryAccentColor",
       },
       ToolWindow: {
+        background: "mantle",
         Button: {
           hoverBackground: "hoverBackground",
         },


### PR DESCRIPTION
Makes the file tree mantle, the top nav bar mantle, and styles the CheckBoxes/Buttons/Spinners/RadioButtons, to better blend in with the new Panel colors in the settings.

![image](https://user-images.githubusercontent.com/79978224/202613271-d8ab57c8-0be3-424e-98e5-b1a994257273.png)

Will close #27, but some more work is needed to further improve appearance.