### PR TITLE
fix: semantic highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - (#53): Highlight Python binary strings
+- (#54): Apply Catppuccin to semantic highlights
 
 ### Changed
 

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -23,6 +23,17 @@ const handlebarsOpacity = (
     .replace("#", "");
 };
 
+const handlebarsMix = (
+  color1: string,
+  color2: string,
+  amount: number,
+): string => {
+  return colormath
+    .mixColor(colormath.hex.toRgb(color1), colormath.hex.toRgb(color2), amount)
+    .hex.toLowerCase()
+    .replace("#", "");
+};
+
 const capitalize = (str: string): string => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
@@ -478,6 +489,7 @@ Object.entries(variants).forEach(([key, value]) => {
 // {{opacity rosewater 0.5}}
 Handlebars.registerHelper("isLatte", handlebarsIsLatte);
 Handlebars.registerHelper("opacity", handlebarsOpacity);
+Handlebars.registerHelper("mix", handlebarsMix);
 
 Deno.readTextFile(templatePath).then((data) => {
   Object.entries(variants).forEach(([key, value]) => {

--- a/generateFlavours/template.xml
+++ b/generateFlavours/template.xml
@@ -2938,5 +2938,31 @@
         <option name="FOREGROUND" value="{{maroon}}"/>
       </value>
     </option>
+    <!-- Semantic Highlights -->
+    <option name="RAINBOW_COLOR0">
+      <value>
+        <option name="FOREGROUND" value="{{mix text red 0.6}}" />
+      </value>
+    </option>
+    <option name="RAINBOW_COLOR1">
+      <value>
+        <option name="FOREGROUND" value="{{mix text yellow 0.6}}" />
+      </value>
+    </option>
+    <option name="RAINBOW_COLOR2">
+      <value>
+        <option name="FOREGROUND" value="{{mix text green 0.6}}" />
+      </value>
+    </option>
+    <option name="RAINBOW_COLOR3">
+      <value>
+        <option name="FOREGROUND" value="{{mix text blue 0.6}}" />
+      </value>
+    </option>
+    <option name="RAINBOW_COLOR4">
+      <value>
+        <option name="FOREGROUND" value="{{mix text mauve 0.6}}" />
+      </value>
+    </option>
   </attributes>
 </scheme>


### PR DESCRIPTION
Uses a `text`/ rainbow color mix of 60%/40%, e.g. `#cdd6f4`/`#f38ba8` => `#dcb8d6`

<img width="266" alt="image" src="https://user-images.githubusercontent.com/79978224/217480444-4dcb3cca-3bf9-4eb5-a766-e7729acd6fed.png">
