### PR TITLE
feat: add selection background for tool window buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add styles to checkboxes and radio buttons
+- Add selection background for tool window buttons
 
 ### Changed
 

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -385,6 +385,7 @@ Object.entries(variants).forEach(([key, value]) => {
         background: "mantle",
         Button: {
           hoverBackground: "hoverBackground",
+          selectedBackground: "hoverBackground",
         },
         Header: {
           background: "primaryBackground",


### PR DESCRIPTION
#### Current Style
<img width="387" alt="Screenshot 2023-03-30 at 13 41 44" src="https://user-images.githubusercontent.com/75334427/228816425-0d5ddb63-6d85-4ca6-aefe-d02fed4f6022.png">
<img width="387" alt="Screenshot 2023-03-30 at 13 42 09" src="https://user-images.githubusercontent.com/75334427/228816436-2c569f46-1448-49c1-bbd2-8d181203dd42.png">

#### New Style
<img width="387" alt="Screenshot 2023-03-30 at 13 43 26" src="https://user-images.githubusercontent.com/75334427/228816466-598ecf73-2027-4fae-b9a8-897e0c9341e0.png">
<img width="387" alt="Screenshot 2023-03-30 at 13 43 30" src="https://user-images.githubusercontent.com/75334427/228816473-2b6f8bef-203e-4901-af7c-b4a3f5074530.png">

