### PR TITLE
feat: add styles to memory indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Add styles to checkboxes and radio buttons
 - Add selection background for tool window buttons
+- Add styles to memory indicator
 
 ### Changed
 

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -249,6 +249,10 @@ Object.entries(variants).forEach(([key, value]) => {
         visitedForeground: "secondaryAccentColor",
         pressedForeground: "secondaryAccentColor",
       },
+      MemoryIndicator: {
+        allocatedBackground: "surface0",
+        usedBackground: "surface1",
+      },
       NotificationsToolwindow: {
         newNotification: {
           background: "primaryBackground",


### PR DESCRIPTION
Add missing style to memory indicator

#### Current Style
<img width="387" alt="Screenshot 2023-03-30 at 14 23 30" src="https://user-images.githubusercontent.com/75334427/228822070-379f46ec-e527-4694-a59f-159a8b560862.png">
<img width="387" alt="Screenshot 2023-03-30 at 14 24 10" src="https://user-images.githubusercontent.com/75334427/228822200-2e4462ab-98d8-4511-8022-5e5d125b28c9.png">


#### New Style
<img width="387" alt="Screenshot 2023-03-30 at 14 25 37" src="https://user-images.githubusercontent.com/75334427/228822123-ff713fde-f132-4e72-a333-afe2e79c8fe4.png">
<img width="387" alt="Screenshot 2023-03-30 at 14 25 53" src="https://user-images.githubusercontent.com/75334427/228822218-8928f27a-2e48-44ea-b414-ae67f40ce238.png">
