### PR TITLE
feat: add styles to main toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add styles to checkboxes and radio buttons
 - Add selection background for tool window buttons
 - Add styles to memory indicator
+- Add styles to main toolbar
 
 ### Changed
 

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -249,6 +249,18 @@ Object.entries(variants).forEach(([key, value]) => {
         visitedForeground: "secondaryAccentColor",
         pressedForeground: "secondaryAccentColor",
       },
+      MainToolbar: {
+        background: "primaryBackground",
+        inactiveBackground: "primaryBackground",
+        Dropdown: {
+          hoverBackground: "hoverBackground",
+          pressedBackground: "hoverBackground",
+        },
+        Icon: {
+          hoverBackground: "hoverBackground",
+          pressedBackground: "hoverBackground",
+        },
+      },
       MemoryIndicator: {
         allocatedBackground: "surface0",
         usedBackground: "surface1",


### PR DESCRIPTION
Add missing style to main toolbar elements

#### Current Style
<img width="387" alt="Screenshot 2023-03-31 at 12 10 47" src="https://user-images.githubusercontent.com/75334427/229079124-6de89039-4823-4a8b-8f76-2801f79ccfff.png">
<img width="387" alt="Screenshot 2023-03-31 at 12 11 13" src="https://user-images.githubusercontent.com/75334427/229079131-03a03a72-3daa-4aa6-8316-a3e66f1c59e5.png">

#### New Style
<img width="387" alt="Screenshot 2023-03-31 at 12 12 33" src="https://user-images.githubusercontent.com/75334427/229079155-b54ea80e-d7ca-4325-820a-b2d4792c3471.png">
<img width="387" alt="Screenshot 2023-03-31 at 12 12 47" src="https://user-images.githubusercontent.com/75334427/229079166-4740a2cd-9ca6-49fe-aa00-94b4815f292f.png">
