### PR TITLE
feat: add background color for plugin tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Add background color for plugin tags
 
 ### Changed
 

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -301,6 +301,7 @@ Object.entries(variants).forEach(([key, value]) => {
         },
         hoverBackground: "hoverBackground",
         lightSelectionBackground: "hoverBackground",
+        tagBackground: "secondaryBackground",
         Button: {
           installBorderColor: "secondaryAccentColor",
           installForeground: "secondaryAccentColor",


### PR DESCRIPTION
Set **secondaryBackground** as background color for plugin tags.

#### Current style
<img width="1285" alt="Screenshot 2023-04-06 at 13 52 02" src="https://user-images.githubusercontent.com/75334427/230358597-cfa2756d-9f86-4e16-b130-389b03a5853d.png">
<img width="1078" alt="Screenshot 2023-04-06 at 13 52 10" src="https://user-images.githubusercontent.com/75334427/230358613-5c6c4a59-b56a-4e37-b1de-42a2b99c196d.png">

#### New Style
<img width="1329" alt="Screenshot 2023-04-06 at 13 52 35" src="https://user-images.githubusercontent.com/75334427/230358676-d02ddb0c-906c-4082-80ba-568439cd95a5.png">
<img width="1078" alt="Screenshot 2023-04-06 at 13 52 58" src="https://user-images.githubusercontent.com/75334427/230358685-bb40b3f1-7193-4fc7-812f-8b76edc39d1a.png">
