### PR TITLE
fix: nix syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Improve Nix syntax highlighting
+
 ### Security
 
 ## 2.2.0 - 2023-06-07

--- a/generateFlavours/template.xml
+++ b/generateFlavours/template.xml
@@ -1842,6 +1842,17 @@
         <option name="FOREGROUND" value="{{peach}}"/>
       </value>
     </option>
+    <option name="NIX_BUILTIN">
+      <value>
+        <option name="FOREGROUND" value="{{red}}" />
+        <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    <option name="NIX_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="{{blue}}" />
+      </value>
+    </option>
     <option name="NOT_TOP_FRAME_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="{{surface0}}"/>


### PR DESCRIPTION
Prev:
![2023-09-18-115329@2x](https://github.com/catppuccin/jetbrains/assets/79978224/7b9b0ca6-d1bf-44a3-ab24-e67e5c2d3c28)

New:
![2023-09-18-115315@2x](https://github.com/catppuccin/jetbrains/assets/79978224/0bb49b01-36e4-46b7-ba14-464390ba53bb)
