### PR TITLE
build: update `platformVersion` to 2022.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: 'gradle'
 
       - name: Setup Deno

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
           cache: 'gradle'
 
       - name: Setup Deno

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.6.10"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.3.1"
+    id("org.jetbrains.intellij") version "1.15.0"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "2.0.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 pluginGroup = com.github.catppuccin
 pluginName = Catppuccin Theme
 pluginVersion = 2.2.0
-pluginSinceBuild = 232
+pluginSinceBuild = 222
 pluginUntilBuild = 232.*
 platformType = IC
-platformVersion = 2023.2
+platformVersion = 2022.2
 platformPlugins =
 javaVersion = 17
 gradleVersion = 7.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 pluginGroup = com.github.catppuccin
 pluginName = Catppuccin Theme
 pluginVersion = 2.2.0
-pluginSinceBuild = 203
+pluginSinceBuild = 232
 pluginUntilBuild = 232.*
 platformType = IC
-platformVersion = 212.5712.43
+platformVersion = 2023.2
 platformPlugins =
-javaVersion = 11
+javaVersion = 17
 gradleVersion = 7.3.3
 kotlin.stdlib.default.dependency = false
 buildSearchableOptions.enabled = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR moves away from IntelliJ 2021, as this is really hard to work on the UI with IntelliJ 2021 that does not have the new UI. And while a lot of users have move to the new UI, this PR seems important to improve the quality of next releases.

The new platformVersion with this PR is ~~2023.2~~ 2022.2.