### PR TITLE
refactor: refine the UI colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add background color for plugin tags
+- Overhaul/Refine user interface for "New UI"
 
 ### Changed
 

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -132,9 +132,20 @@ Object.entries(variants).forEach(([key, value]) => {
           leftRightInset: 8,
         }
       },
+      Banner: {
+        informativeForeground: "primaryForeground",
+        informativeBackground: "#" + opacity(value.blue.hex, 0.1),
+        informativeBorderColor: "#" + opacity(value.blue.hex, 0.15),
+        errorForeground: "primaryForeground",
+        errorBackground: "#" + opacity(value.red.hex, 0.1),
+        errorBorderColor: "#" + opacity(value.red.hex, 0.15),
+        warningForeground: "primaryForeground",
+        warningBackground: "#" + opacity(value.peach.hex, 0.1),
+        warningBorderColor: "#" + opacity(value.peach.hex, 0.15),
+      },
       Borders: {
         color: "borderColor",
-        ContrastBorderColor: "secondaryBackground",
+        ContrastBorderColor: "separatorColor",
       },
       ActionButton: {
         hoverBackground: "hoverBackground",
@@ -238,23 +249,23 @@ Object.entries(variants).forEach(([key, value]) => {
       },
       FileColor: {
         Blue: '#' + (isLatte
-          ? opacity(value.blue.hex, 0.2)
-          : opacity(value.blue.hex, 0.15)),
+          ? opacity(value.blue.hex, 0.15)
+          : opacity(value.blue.hex, 0.10)),
         Green: '#' + (isLatte
-          ? opacity(value.green.hex, 0.2)
-          : opacity(value.green.hex, 0.15)),
+          ? opacity(value.green.hex, 0.15)
+          : opacity(value.green.hex, 0.10)),
         Orange: '#' + (isLatte
-          ? opacity(value.peach.hex, 0.2)
-          : opacity(value.peach.hex, 0.15)),
+          ? opacity(value.peach.hex, 0.15)
+          : opacity(value.peach.hex, 0.10)),
         Yellow: '#' + (isLatte
-          ? opacity(value.yellow.hex, 0.2)
-          : opacity(value.yellow.hex, 0.15)),
+          ? opacity(value.yellow.hex, 0.15)
+          : opacity(value.yellow.hex, 0.10)),
         Rose: '#' + (isLatte
-          ? opacity(value.red.hex, 0.2)
-          : opacity(value.red.hex, 0.15)),
+          ? opacity(value.red.hex, 0.15)
+          : opacity(value.red.hex, 0.10)),
         Violet: '#' + (isLatte
-          ? opacity(value.lavender.hex, 0.2)
-          : opacity(value.lavender.hex, 0.15)),
+          ? opacity(value.lavender.hex, 0.15)
+          : opacity(value.lavender.hex, 0.10)),
       },
       Link: {
         activeForeground: "accentColor",

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -333,7 +333,9 @@ Object.entries(variants).forEach(([key, value]) => {
         passedColor: "green",
       },
       Popup: {
-        borderColor: "surface1",
+        borderWidth: 1,
+        paintBorder: true,
+        borderColor: "separatorColor",
         Header: {
           activeBackground: "mantle",
           inactiveBackground: "mantle",

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -124,8 +124,13 @@ Object.entries(variants).forEach(([key, value]) => {
         separatorColor: "separatorColor",
       },
       List: {
-        rowHeight: 24,
+        rowHeight: "24",
+        border: "4,0,4,0",
         background: "mantle",
+        Button: {
+          separatorInset: 4,
+          leftRightInset: 8,
+        }
       },
       Borders: {
         color: "borderColor",
@@ -216,13 +221,20 @@ Object.entries(variants).forEach(([key, value]) => {
         background: "primaryBackground",
         shortcutForeground: "accentColor",
       },
+      EditorPane: {
+        splitBorder: "separatorColor"
+      },
       EditorTabs: {
+        underlineArc: 4,
+        unselectedBlend: 0.7,
         background: "base",
-        underlinedTabBackground: "base",
+        underlinedTabBackground: "mantle",
         underlineColor: "accentColor",
         underlineHeight: 1,
         hoverBackground: "base",
         inactiveUnderlineColor: "lavender",
+        inactiveHoverBackground: "red",
+        underTabsBorderColor: "separatorColor",
       },
       FileColor: {
         Blue: '#' + (isLatte
@@ -253,13 +265,15 @@ Object.entries(variants).forEach(([key, value]) => {
       MainToolbar: {
         background: "crust",
         inactiveBackground: "mantle",
-        Dropdown: {
-          hoverBackground: "hoverBackground",
-          pressedBackground: "hoverBackground",
-        },
         Icon: {
           hoverBackground: "hoverBackground",
           pressedBackground: "hoverBackground",
+          insets: "5,5,5,5",
+        },
+        Dropdown: {
+          hoverBackground: "hoverBackground",
+          pressedBackground: "hoverBackground",
+          maxWidth: 350,
         },
       },
       MemoryIndicator: {
@@ -336,6 +350,9 @@ Object.entries(variants).forEach(([key, value]) => {
         borderWidth: 1,
         paintBorder: true,
         borderColor: "separatorColor",
+        Advertiser: {
+          fontSizeOffset: -1
+        },
         Header: {
           activeBackground: "mantle",
           inactiveBackground: "mantle",
@@ -372,8 +389,13 @@ Object.entries(variants).forEach(([key, value]) => {
         background: "mantle",
         borderColor: "borderColor",
         hoverBackground: "hoverBackground",
+        Breadcrumbs: {
+          chevronInset: 0,
+        }
       },
       TabbedPane: {
+        tabHeight: 40,
+        tabSelectionArc: 4,
         tabSelectionHeight: 1,
         focusColor: "hoverBackground",
         hoverColor: "hoverBackground",
@@ -425,6 +447,7 @@ Object.entries(variants).forEach(([key, value]) => {
       },
       Tree: {
         rowHeight: 24,
+        border: "4,12,4,12",
         background: "mantle",
         modifiedItemForeground: "accentColor",
         hoverBackground: "secondaryBackground",

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -108,7 +108,7 @@ Object.entries(variants).forEach(([key, value]) => {
       selectionBackground: colors.surface0,
       selectionInactiveBackground: colors.base,
       borderColor: colors.base,
-      separatorColor: colors.base,
+      separatorColor: colors.surface0,
     },
     ui: {
       "*": {
@@ -120,7 +120,7 @@ Object.entries(variants).forEach(([key, value]) => {
         selectionInactiveBackground: "selectionInactiveBackground",
         inactiveBackground: "primaryBackground",
         disabledBackground: "primaryBackground",
-        borderColor: "primaryBackground",
+        borderColor: "borderColor",
         separatorColor: "separatorColor",
       },
       List: {
@@ -128,7 +128,7 @@ Object.entries(variants).forEach(([key, value]) => {
         background: "mantle",
       },
       Borders: {
-        color: "primaryBackground",
+        color: "borderColor",
         ContrastBorderColor: "secondaryBackground",
       },
       ActionButton: {
@@ -218,11 +218,11 @@ Object.entries(variants).forEach(([key, value]) => {
       },
       EditorTabs: {
         background: "base",
-        underlinedTabBackground: "secondaryBackground",
+        underlinedTabBackground: "base",
         underlineColor: "accentColor",
         underlineHeight: 1,
-        hoverBackground: "surface0",
-        inactiveUnderlineColor: "accentColor",
+        hoverBackground: "base",
+        inactiveUnderlineColor: "lavender",
       },
       FileColor: {
         Blue: '#' + (isLatte
@@ -412,10 +412,10 @@ Object.entries(variants).forEach(([key, value]) => {
         Header: {
           background: "mantle",
           inactiveBackground: "mantle",
-          borderColor: "primaryBackground",
+          borderColor: "borderColor",
         },
         HeaderTab: {
-          underlineColor: "pink",
+          underlineColor: "accentColor",
           inactiveUnderlineColor: "text",
           underlineHeight: 1,
           hoverBackground: "surface0",

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -472,6 +472,9 @@ Object.entries(variants).forEach(([key, value]) => {
           },
         },
       },
+      CheckBox: {
+        background: "mantle",
+      }
     },
     icons: {
       ColorPalette: {

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -104,11 +104,11 @@ Object.entries(variants).forEach(([key, value]) => {
       primaryForeground: colors.text,
       primaryBackground: colors.base,
       secondaryBackground: colors.surface0,
-      hoverBackground: colors.surface1,
-      selectionBackground: colors.surface1,
+      hoverBackground: colors.surface0,
+      selectionBackground: colors.surface0,
       selectionInactiveBackground: colors.base,
-      borderColor: colors.surface1,
-      separatorColor: colors.surface1,
+      borderColor: colors.base,
+      separatorColor: colors.base,
     },
     ui: {
       "*": {
@@ -124,6 +124,7 @@ Object.entries(variants).forEach(([key, value]) => {
         separatorColor: "separatorColor",
       },
       List: {
+        rowHeight: 24,
         background: "mantle",
       },
       Borders: {
@@ -216,7 +217,7 @@ Object.entries(variants).forEach(([key, value]) => {
         shortcutForeground: "accentColor",
       },
       EditorTabs: {
-        background: "primaryBackground",
+        background: "base",
         underlinedTabBackground: "secondaryBackground",
         underlineColor: "accentColor",
         underlineHeight: 1,
@@ -250,8 +251,8 @@ Object.entries(variants).forEach(([key, value]) => {
         pressedForeground: "secondaryAccentColor",
       },
       MainToolbar: {
-        background: "primaryBackground",
-        inactiveBackground: "primaryBackground",
+        background: "crust",
+        inactiveBackground: "mantle",
         Dropdown: {
           hoverBackground: "hoverBackground",
           pressedBackground: "hoverBackground",
@@ -272,8 +273,8 @@ Object.entries(variants).forEach(([key, value]) => {
         },
       },
       Notification: {
-        background: "primaryBackground",
-        borderColor: "mauve",
+        background: "mantle",
+        borderColor: "surface0",
         errorBorderColor: "red",
         errorBackground: "primaryBackground",
         errorForeground: "primaryForeground",
@@ -288,6 +289,9 @@ Object.entries(variants).forEach(([key, value]) => {
           informativeBackground: "primaryBackground",
           informativeBorderColor: "secondaryAccentColor",
         },
+      },
+      Panel: {
+        background: "mantle"
       },
       PasswordField: {
         background: "secondaryBackground",
@@ -329,10 +333,10 @@ Object.entries(variants).forEach(([key, value]) => {
         passedColor: "green",
       },
       Popup: {
-        borderColor: "mauve",
+        borderColor: "surface1",
         Header: {
-          activeBackground: "secondaryBackground",
-          inactiveBackground: "secondaryBackground",
+          activeBackground: "mantle",
+          inactiveBackground: "mantle",
         },
       },
       ScrollBar: {
@@ -363,6 +367,7 @@ Object.entries(variants).forEach(([key, value]) => {
         background: "mantle",
       },
       StatusBar: {
+        background: "mantle",
         borderColor: "borderColor",
         hoverBackground: "hoverBackground",
       },
@@ -395,7 +400,7 @@ Object.entries(variants).forEach(([key, value]) => {
         buttonColor: "primaryForeground",
       },
       ToolBar: {
-        background: "primaryBackground",
+        background: "mantle",
         borderHandleColor: "secondaryAccentColor",
       },
       ToolWindow: {
@@ -405,17 +410,15 @@ Object.entries(variants).forEach(([key, value]) => {
           selectedBackground: "hoverBackground",
         },
         Header: {
-          background: "primaryBackground",
-          inactiveBackground: "primaryBackground",
-          borderColor: "secondaryBackground",
+          background: "mantle",
+          inactiveBackground: "mantle",
+          borderColor: "primaryBackground",
         },
         HeaderTab: {
           underlineColor: "pink",
           inactiveUnderlineColor: "text",
           underlineHeight: 1,
-          underlinedTabBackground: "surface1",
-          selectedInactiveBackground: "base",
-          hoverBackground: "hoverBackground",
+          hoverBackground: "surface0",
         },
       },
       Tree: {
@@ -457,7 +460,7 @@ Object.entries(variants).forEach(([key, value]) => {
       },
       WelcomeScreen: {
         SidePanel: {
-          background: "secondaryBackground",
+          background: "mantle",
         },
         separatorColor: "separatorColor",
         Projects: {
@@ -489,7 +492,7 @@ Object.entries(variants).forEach(([key, value]) => {
         "Objects.Yellow": colors.yellow,
         "Objects.YellowDark": colors.flamingo,
         "Objects.BlackText": colors.surface0,
-        "Tree.iconColor": colors.blue,
+        "Tree.iconColor": colors.text,
         "Checkbox.Background.Default": colors.surface1,
         "Checkbox.Background.Selected": colors.surface1,
         "Checkbox.Background.Disabled": colors.surface0,
@@ -500,7 +503,7 @@ Object.entries(variants).forEach(([key, value]) => {
         "Checkbox.Border.Disabled": colors.surface0,
       },
     },
-  };
+  }
 
   Deno.writeTextFileSync(
     path.join(themePath, `${key}.theme.json`),

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -225,24 +225,24 @@ Object.entries(variants).forEach(([key, value]) => {
         inactiveUnderlineColor: "accentColor",
       },
       FileColor: {
-        Blue: isLatte
+        Blue: '#' + (isLatte
           ? opacity(value.blue.hex, 0.2)
-          : opacity(value.blue.hex, 0.15),
-        Green: isLatte
+          : opacity(value.blue.hex, 0.15)),
+        Green: '#' + (isLatte
           ? opacity(value.green.hex, 0.2)
-          : opacity(value.green.hex, 0.15),
-        Orange: isLatte
+          : opacity(value.green.hex, 0.15)),
+        Orange: '#' + (isLatte
           ? opacity(value.peach.hex, 0.2)
-          : opacity(value.peach.hex, 0.15),
-        Yellow: isLatte
+          : opacity(value.peach.hex, 0.15)),
+        Yellow: '#' + (isLatte
           ? opacity(value.yellow.hex, 0.2)
-          : opacity(value.yellow.hex, 0.15),
-        Rose: isLatte
+          : opacity(value.yellow.hex, 0.15)),
+        Rose: '#' + (isLatte
           ? opacity(value.red.hex, 0.2)
-          : opacity(value.red.hex, 0.15),
-        Violet: isLatte
+          : opacity(value.red.hex, 0.15)),
+        Violet: '#' + (isLatte
           ? opacity(value.lavender.hex, 0.2)
-          : opacity(value.lavender.hex, 0.15),
+          : opacity(value.lavender.hex, 0.15)),
       },
       Link: {
         activeForeground: "accentColor",

--- a/generateFlavours/main.ts
+++ b/generateFlavours/main.ts
@@ -206,9 +206,10 @@ Object.entries(variants).forEach(([key, value]) => {
         nonEditableBackground: "secondaryBackground",
       },
       CompletionPopup: {
-        selectionBackground: "selectionBackground",
-        selectionInactiveBackground: "selectionBackground",
-        matchForeground: "flamingo",
+        foreground: "text",
+        selectionBackground: "surface1",
+        selectionInactiveBackground: "surface0",
+        matchForeground: "mauve",
       },
       Component: {
         focusColor: "accentColor",
@@ -361,7 +362,10 @@ Object.entries(variants).forEach(([key, value]) => {
         borderWidth: 1,
         paintBorder: true,
         borderColor: "separatorColor",
+        inactiveBorderColor: "separatorColor",
         Advertiser: {
+          background: "mantle",
+          foreground: "text",
           fontSizeOffset: -1
         },
         Header: {

--- a/generateFlavours/template.xml
+++ b/generateFlavours/template.xml
@@ -64,7 +64,7 @@
     <option name="ScrollBar.thumbColor" value="{{opacity surface1 0.45}}"/>
     <option name="ScrollBar.Mac.hoverThumbColor" value="{{opacity overlay0 0.4}}"/>
     <option name="ScrollBar.Mac.thumbColor" value="{{opacity surface1 0.45}}"/>
-    <option name="TAB_UNDERLINE" value="{{pink}}"/>
+    <option name="TAB_UNDERLINE" value="{{mauve}}"/>
     <option name="TAB_UNDERLINE_INACTIVE" value="{{text}}"/>
     <option name="TEARLINE_COLOR" value="{{surface0}}"/>
     <option name="VCS_ANNOTATIONS_COLOR_1" value="{{opacity mauve 0.6}}"/>
@@ -2656,13 +2656,13 @@
     </option>
     <option name="TAB_SELECTED">
       <value>
-        <option name="FOREGROUND" value="{{pink}}"/>
+        <option name="FOREGROUND" value="{{mauve}}"/>
         <option name="BACKGROUND" value="{{surface0}}"/>
       </value>
     </option>
     <option name="TAB_SELECTED_INACTIVE">
       <value>
-        <option name="FOREGROUND" value="{{pink}}"/>
+        <option name="FOREGROUND" value="{{mauve}}"/>
         <option name="BACKGROUND" value="{{surface0}}"/>
       </value>
     </option>


### PR DESCRIPTION
It may seem subtle at first glance but I think it's much more balanced like that. This also fixes list item height that were really small in some menus.

## Before

<img width="1828" alt="image-5" src="https://github.com/catppuccin/jetbrains/assets/12123721/a6afc589-bfef-4bc1-9f60-729a2895c5b6">

## After

<img width="1825" alt="image-4" src="https://github.com/catppuccin/jetbrains/assets/12123721/14ebc141-30a3-4ded-95e8-ef6434214ba5">

## TODO

- [x] Merge #88 
- [x] Fix the bottom bar (the right item is off)
- [x] Fix the background color in some popups.
- [ ] Fix the completion popup