### PR TITLE
feat: make references in go comments distinguishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Improve Nix syntax highlighting
+- (Go): Make references in comments distinguishable
 
 ### Security
 

--- a/generateFlavours/template.xml
+++ b/generateFlavours/template.xml
@@ -1120,6 +1120,12 @@
         <option name="FOREGROUND" value="{{mauve}}"/>
       </value>
     </option>
+    <option name="GO_COMMENT_REFERENCE">
+      <value>
+        <option name="FOREGROUND" value="{{overlay2}}"/>
+        <option name="FONT_TYPE" value="2"/>
+      </value>
+    </option>
     <option name="GO_EXPORTED_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
     <option name="GO_LOCAL_FUNCTION_CALL" baseAttributes="DEFAULT_FUNCTION_CALL"/>
     <option name="GO_COMMENT_REFERENCE" baseAttributes="DEFAULT_LINE_COMMENT"/>


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![before](https://github.com/catppuccin/jetbrains/assets/43011723/bd3c7a7c-7544-47e6-89ac-04bea8bbbb41) | ![after](https://github.com/catppuccin/jetbrains/assets/43011723/3c7a256f-fef7-4a3d-ab71-d2edf8799644) |

- Closes #75