### PR TITLE
fix: Prevent the Go Template background colors to inherit default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Fixed
 
 - Improve Nix syntax highlighting
-- (Go Template): Prevent the Go Template background colors to inherit default
+- (Go): Fix template syntax highlighting
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Improve Nix syntax highlighting
+- (Go Template): Prevent the Go Template background colors to inherit default
 
 ### Security
 

--- a/generateFlavours/template.xml
+++ b/generateFlavours/template.xml
@@ -1145,6 +1145,9 @@
         <option name="EFFECT_TYPE" value="1"/>
       </value>
     </option>
+    <option name="GO_TEMPLATE_BACKGROUND">
+      <value />
+    </option>
     <option name="GO_TYPE_REFERENCE">
       <value>
         <option name="FOREGROUND" value="{{teal}}"/>


### PR DESCRIPTION
Before it pretty much inherited from the default template language foreground, which made everything a single color instead of following the highlighting set up.

| Before | After |
|--------|--------|
| ![before](https://github.com/catppuccin/jetbrains/assets/43011723/b44cfcd4-e8f4-4402-82f2-35363d648274) | ![after](https://github.com/catppuccin/jetbrains/assets/43011723/08d2e9bf-6a3a-4199-8d0a-5a5f54e0e52d) | 