### PR TITLE
feat: add background to search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improve Nix syntax highlighting
 - (Go): Make references in comments distinguishable
 - (Go): Fix template syntax highlighting
+- Highlight background of search results consistency
 
 ### Security
 

--- a/generateFlavours/template.xml
+++ b/generateFlavours/template.xml
@@ -2479,7 +2479,7 @@
     <option name="SASS_VARIABLE" baseAttributes="DEFAULT_INSTANCE_FIELD"/>
     <option name="SEARCH_RESULT_ATTRIBUTES">
       <value>
-        <option name="BACKGROUND" value="{{base}}"/>
+        <option name="BACKGROUND" value="{{opacity blue 0.3}}"/>
       </value>
     </option>
     <option name="SLIM_BAD_CHARACTER">


### PR DESCRIPTION
Previously when searching by using the "Replace in files" feature the background was of color `base`, which isn't ideal. Changed to be the same as other backgrounds when searching, which results in:

| Before | After |
|--------|--------|
| ![Before 'Replace in files'](https://github.com/catppuccin/jetbrains/assets/43011723/4e860e14-19a2-4fcf-9b33-5a227af5861c) | ![After 'Replace in files'](https://github.com/catppuccin/jetbrains/assets/43011723/95e1474c-bf82-43d3-b82a-40bb53df8600)| 

At the same time it apparently helps to solve one part of #72, specifically the first issue the user mentioned - not sure what they mean with the second though:

| Before | After |
|--------|--------|
| ![Select statement before](https://github.com/catppuccin/jetbrains/assets/43011723/62766f8a-9b1c-4ba5-977b-8d523a731f4f) | ![Select statement after](https://github.com/catppuccin/jetbrains/assets/43011723/f6ebc4cd-10b3-483d-8818-e9185147ed48) | 