### PR TITLE
feat: catppuccin vscode-icons

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ indent_style = tab
 indent_size = 4
 
 # python
-[*.{ini,py,py.tpl,rst}]
+[*.{ini,py,py.tpl,rst,kt,kts}]
 indent_size = 4
 
 # rust

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/resources/icons"]
+	path = src/main/resources/icons
+	url = https://github.com/catppuccin/vscode-icons.git

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ intellij {
 changelog {
     version.set(properties("pluginVersion"))
     path.set(file("CHANGELOG.md").canonicalPath)
-    header.set(provider { "${version.get()} - ${date()}"})
+    header.set(provider { "${version.get()} - ${date()}" })
     headerParserRegex.set("""(\d\.\d\.\d)""".toRegex())
     itemPrefix.set("-")
     keepUnreleasedSection.set(true)
@@ -68,7 +68,7 @@ tasks {
 
         // Get the latest available change notes from the changelog file
         changeNotes.set(provider {
-          changelog.renderItem(changelog.getLatest(), Changelog.OutputType.HTML)
+            changelog.renderItem(changelog.getLatest(), Changelog.OutputType.HTML)
         })
     }
 

--- a/src/main/kotlin/com/github/catppuccin/jetbrains/icons/CatppuccinIconProvider.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains/icons/CatppuccinIconProvider.kt
@@ -1,0 +1,22 @@
+package com.github.catppuccin.jetbrains.icons
+
+import com.intellij.ide.IconProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiUtilCore
+import javax.swing.Icon
+
+class CatppuccinIconProvider : IconProvider() {
+    override fun getIcon(element: PsiElement, flags: Int): Icon? {
+        var icon: Icon? = null
+        val virtualFile = PsiUtilCore.getVirtualFile(element)
+
+        if (virtualFile != null) {
+            val fileName = virtualFile.name
+            if (fileName.endsWith(".md")) {
+                icon = CatppuccinIcons.MARKDOWN_FILE;
+            }
+        }
+
+        return icon
+    }
+}

--- a/src/main/kotlin/com/github/catppuccin/jetbrains/icons/CatppuccinIcons.kt
+++ b/src/main/kotlin/com/github/catppuccin/jetbrains/icons/CatppuccinIcons.kt
@@ -1,0 +1,9 @@
+package com.github.catppuccin.jetbrains.icons
+
+import javax.swing.Icon
+import com.intellij.openapi.util.IconLoader
+
+object CatppuccinIcons {
+    @JvmField
+    val MARKDOWN_FILE: Icon = IconLoader.getIcon("/icons/icons/markdown.svg", javaClass)
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,5 +50,9 @@ For further help, see also:
     <bundledColorScheme path="/themes/frappe-no-italics"/>
     <bundledColorScheme path="/themes/macchiato-no-italics"/>
     <bundledColorScheme path="/themes/mocha-no-italics"/>
+
+    <iconProvider implementation="com.github.catppuccin.jetbrains.icons.CatppuccinIconProvider"
+                  order="first"
+                  id="CatppuccinIconProvider"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
This PR shows the basics to patch icons (related to #76).

The PR is not done to be merged in this plugin, as we plan to separate the themes from the icons, but it is here for now for documentation purposes.

The current issue with this is that SVG icons are not in the right format for JetBrains.
Cfr. SDK: https://plugins.jetbrains.com/docs/intellij/work-with-icons-and-images.html#svg-format.

<details>
<summary>With /src/icons</summary>

![image](https://github.com/catppuccin/jetbrains/assets/12123721/2a856018-96a9-42ba-bb0c-dda48d19ed7b)

</details>

<details>
<summary>With /icons</summary>

![image](https://github.com/catppuccin/jetbrains/assets/12123721/d5634b16-06f0-4dce-9fff-54ed2ec6d39f)

</details>

Also, the submodule is not ideal for now. We should find a solution to make vscode-icons more generic.