### PR TITLE
fix: improve contrast of `SearchMatch` on Latte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- (UI - Latte): Search contrast on the Search Everywhere popup
+
 ### Security
 
 ## 3.3.1 - 2024-05-27

--- a/generateFlavours/ui.theme.json
+++ b/generateFlavours/ui.theme.json
@@ -338,8 +338,8 @@
       }
     },
     "SearchMatch": {
-      "endBackground": "accentColor",
-      "startBackground": "accentColor"
+      "endBackground": "secondaryAccentColor",
+      "startBackground": "secondaryAccentColor"
     },
     "SegmentedButton": {
       "focusedSelectedButtonColor": "secondaryBackground",

--- a/generateFlavours/ui.theme.json
+++ b/generateFlavours/ui.theme.json
@@ -338,8 +338,8 @@
       }
     },
     "SearchMatch": {
-      "endBackground": "secondaryAccentColor",
-      "startBackground": "secondaryAccentColor"
+      "endBackground": "{{isLatte (opacityWithHex mauve 0.5) mauve}}",
+      "startBackground": "{{isLatte (opacityWithHex mauve 0.5) mauve}}"
     },
     "SegmentedButton": {
       "focusedSelectedButtonColor": "secondaryBackground",


### PR DESCRIPTION
Before:
![CleanShot 2024-08-21 at 01 40 57](https://github.com/user-attachments/assets/da7705e9-e7bc-4d23-80ca-a7b551799b1e)

After:
![CleanShot 2024-08-21 at 01 34 57](https://github.com/user-attachments/assets/d775bc2c-15f3-422c-8c6d-142d32659f90)

fixes #123 