### PR TITLE
fix: change unused code colour to `overlay2`

### DIFF
--- a/generateFlavours/editor.xml
+++ b/generateFlavours/editor.xml
@@ -2030,7 +2030,7 @@
     </option>
     <option name="NOT_USED_ELEMENT_ATTRIBUTES">
       <value>
-        <option name="FOREGROUND" value="{{surface2}}"/>
+        <option name="FOREGROUND" value="{{overlay2}}"/>
       </value>
     </option>
     <option name="OC.CLASS_REFERENCE">


### PR DESCRIPTION
Closes #119.

<img width="529" alt="image" src="https://github.com/user-attachments/assets/56c7a8fb-9487-4e44-844e-d761e0c67a94">
