### PR TITLE
fix: set error stripe mark for selected identifiers to teal

### DIFF
--- a/generateFlavours/editor.xml
+++ b/generateFlavours/editor.xml
@@ -1384,7 +1384,7 @@
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="{{surface2}}"/>
-        <option name="ERROR_STRIPE_COLOR" value="{{surface1}}"/>
+        <option name="ERROR_STRIPE_COLOR" value="{{teal}}"/>
       </value>
     </option>
     <option name="IMPLICIT_ANONYMOUS_CLASS_PARAMETER_ATTRIBUTES">
@@ -2954,7 +2954,7 @@
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="{{surface2}}"/>
-        <option name="ERROR_STRIPE_COLOR" value="{{surface1}}"/>
+        <option name="ERROR_STRIPE_COLOR" value="{{teal}}"/>
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">


### PR DESCRIPTION
Fixes #166

<img width="454" alt="Screenshot 2024-10-10 at 7 30 57 pm" src="https://github.com/user-attachments/assets/965c0d3b-ff8f-4f2f-9acf-3db6fe4d9232">
