### PR TITLE
fix: set scala predefined types to `yellow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- (Scala): Make predefined types (Int, Double, etc) distinguishable from unused
+
 ### Security
 
 ## 3.3.4 - 2024-10-10

--- a/generateFlavours/editor.xml
+++ b/generateFlavours/editor.xml
@@ -2820,7 +2820,7 @@
     <option name="Scala Mutable Collection" baseAttributes="DEFAULT_IDENTIFIER"/>
     <option name="Scala Predefined types">
       <value>
-        <option name="FOREGROUND" value="{{mauve}}" />
+        <option name="FOREGROUND" value="{{yellow}}" />
       </value>
     </option>
     <option name="Scala Type Alias" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES"/>

--- a/generateFlavours/editor.xml
+++ b/generateFlavours/editor.xml
@@ -2818,6 +2818,11 @@
     <option name="SWIFT_SHEBANG_COMMENT" baseAttributes="DEFAULT_LINE_COMMENT"/>
     <option name="Scala Immutable Collection" baseAttributes="DEFAULT_IDENTIFIER"/>
     <option name="Scala Mutable Collection" baseAttributes="DEFAULT_IDENTIFIER"/>
+    <option name="Scala Predefined types">
+      <value>
+        <option name="FOREGROUND" value="{{mauve}}" />
+      </value>
+    </option>
     <option name="Scala Type Alias" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES"/>
     <option name="Scala Type parameter" baseAttributes="TYPE_PARAMETER_NAME_ATTRIBUTES"/>
     <option name="Static method access" baseAttributes="STATIC_METHOD_ATTRIBUTES"/>


### PR DESCRIPTION
This is same color as keywords, which is what intellij default color scheme uses.

Before:
<img width="596" alt="before" src="https://github.com/user-attachments/assets/e79bc08a-72da-4d3a-92d9-04af1a811058">
After:
<img width="589" alt="after" src="https://github.com/user-attachments/assets/d2dbd31b-0afd-4127-8091-2fdd6a5b4ecc">

Alternative options:
`DEFAULT_PREDEFINED_SYMBOL` uses `lavender` with italics. I think it could make sense to use `lavender`, but predefined types appearing italic would look weird, IMHO.

Another option is to use `yellow` and make it same color as other types (`String` in screenshot).