### PR TITLE
fix: set `Component.infoForeground` to `subtext0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - (Scala): Make predefined types (Int, Double, etc) distinguishable from unused
+- (UI): Theme informational text.
 
 ### Security
 

--- a/generateFlavours/ui.theme.json
+++ b/generateFlavours/ui.theme.json
@@ -143,7 +143,8 @@
       "iconColor": "primaryForeground",
       "inactiveErrorFocusColor": "red",
       "inactiveWarningFocusColor": "yellow",
-      "warningFocusColor": "yellow"
+      "warningFocusColor": "yellow",
+      "infoForeground": "subtext0"
     },
     "Counter": {
       "background": "accentColor",


### PR DESCRIPTION
Themes text like this in the UI.
 
 
![image](https://github.com/user-attachments/assets/77275e5a-d5a6-4786-9aaf-773cad52ba76)
