### PR TITLE
fix(UI): theme macOS project tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,15 @@
 
 ### Changed
 
-- (UI): Enhance colors of new UI macOS tabs to make them look native
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- (Scala): Make predefined types (Int, Double, etc) distinguishable from unused
+- (Scala): Make predefined types (Int, Double, etc) distinguishable from unused.
 - (UI): Theme informational text.
+- (UI): Theme macOS project tabs.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- (UI): Enhance colors of new UI macOS tabs to make them look native
+
 ### Deprecated
 
 ### Removed

--- a/generateFlavours/ui.theme.json
+++ b/generateFlavours/ui.theme.json
@@ -223,6 +223,19 @@
       "background": "crust",
       "inactiveBackground": "panelBackground"
     },
+    "MainWindow": {
+      "Tab": {
+        "background": "panelBackground",
+        "borderColor": "panelBackground",
+        "foreground": "{{opacityWithHex primaryForeground 0.5}}",
+        "hoverBackground": "{{opacityWithHex panelBackground 0.7}}",
+        "hoverForeground": "{{opacityWithHex primaryForeground 0.5}}",
+        "selectedBackground": "primaryBackground",
+        "selectedForeground": "primaryForeground",
+        "selectedInactiveBackground": "panelBackground",
+        "separatorColor": "panelBackground"
+      }
+    },
     "MemoryIndicator": {
       "allocatedBackground": "surface0",
       "usedBackground": "surface1"


### PR DESCRIPTION
## Inspiration

<img width="500" alt="image" src="https://github.com/user-attachments/assets/8f5ff1bd-9fa6-4efd-8e34-b7965f4d370b">

## Before

![image](https://github.com/user-attachments/assets/c51803f5-d9fc-47ec-8fa7-f449e0346311)

The selected one is gray out and the other have the panel color.

## After

![image](https://github.com/user-attachments/assets/3b7e5a80-66bc-4d82-9df5-dc3332e30a55)

