### PR TITLE
feat(xaml): improve syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- (XAML): Improve syntax highlighting
+
 ### Changed
 
 ### Deprecated

--- a/generateFlavours/editor.xml
+++ b/generateFlavours/editor.xml
@@ -2628,22 +2628,22 @@
         <option name="FOREGROUND" value="{{blue}}"/>
       </value>
     </option>
-    <option name="ReSharper.XAML_NAMESPACE_ALIAS">
+    <option name="ReSharper.XAML_CLASS">
       <value>
-        <option name="FOREGROUND" value="{{peach}}" />
-      </value>
-    </option>
-    <option name="ReSharper.XAML_PREDEFINED_ELEMENT">
-      <value>
-        <option name="FOREGROUND" value="{{mauve}}" />
+        <option name="FOREGROUND" value="{{blue}}" />
         {{#if italics}}
         <option name="FONT_TYPE" value="2" />
         {{/if}}
       </value>
     </option>
-    <option name="ReSharper.XAML_STYLE_CLASS">
+    <option name="ReSharper.XAML_NAMESPACE_ALIAS">
       <value>
-        <option name="FOREGROUND" value="{{teal}}" />
+        <option name="FOREGROUND" value="{{yellow}}" />
+      </value>
+    </option>
+    <option name="ReSharper.XAML_PROPERTY_IDENTIFIER">
+      <value>
+        <option name="FOREGROUND" value="{{yellow}}" />
       </value>
     </option>
     <option name="SASS_COMMENT" baseAttributes="CSS.COMMENT"/>

--- a/generateFlavours/editor.xml
+++ b/generateFlavours/editor.xml
@@ -2628,6 +2628,24 @@
         <option name="FOREGROUND" value="{{blue}}"/>
       </value>
     </option>
+    <option name="ReSharper.XAML_NAMESPACE_ALIAS">
+      <value>
+        <option name="FOREGROUND" value="{{peach}}" />
+      </value>
+    </option>
+    <option name="ReSharper.XAML_PREDEFINED_ELEMENT">
+      <value>
+        <option name="FOREGROUND" value="{{mauve}}" />
+        {{#if italics}}
+        <option name="FONT_TYPE" value="2" />
+        {{/if}}
+      </value>
+    </option>
+    <option name="ReSharper.XAML_STYLE_CLASS">
+      <value>
+        <option name="FOREGROUND" value="{{teal}}" />
+      </value>
+    </option>
     <option name="SASS_COMMENT" baseAttributes="CSS.COMMENT"/>
     <option name="SASS_MIXIN">
       <value>


### PR DESCRIPTION
Initial changes didn't fit quite right. Instead, colors are set to more closely resemble xml colors. The style guide is rather hard to represent currently given the options for xaml styling are extremely limited. Any other opportunities for changes will have to wait.