### PR TITLE
fix: IDE freezing/crashing by setting `paintBorder: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- IDE freezing/crashing due to internal error when painting popup borders (https://youtrack.jetbrains.com/issue/JBR-7981/Intellij-2024.3-freezes-continuously-on-opening-Context-Menu-Opt-Enter)
+
 ### Security
 
 ## 3.4.0 - 2024-11-13

--- a/generateFlavours/ui.theme.json
+++ b/generateFlavours/ui.theme.json
@@ -311,7 +311,7 @@
       "borderColor": "separatorColor",
       "borderWidth": 1,
       "inactiveBorderColor": "separatorColor",
-      "paintBorder": true
+      "paintBorder": false
     },
     "ProgressBar": {
       "failedColor": "red",


### PR DESCRIPTION
Solves #190.

Inspired by this [comment](https://youtrack.jetbrains.com/issue/JBR-7981).

Tested on 2 unrelated install.

[Catppuccin Theme-3.4.0-crash-fix.zip](https://github.com/user-attachments/files/18621488/Catppuccin.Theme-3.4.0-crash-fix.zip)