### PR TITLE
chore: Upgrade Gradle 7.3 -> 8.14

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ platformType = IC
 platformVersion = 2023.1
 platformPlugins =
 javaVersion = 17
-gradleVersion = 7.3.3
+gradleVersion = 8.14
 kotlin.stdlib.default.dependency = false
 buildSearchableOptions.enabled = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary

Just upgrades Gradle, no other changes made.

### Deprecations

This does cause new deprecation warnings, but one will be resolved by upgrading to [IntelliJ Platform Gradle Plugin 2.x](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html) and the other I'm not sure how to solve. Maybe it has to do with the Kotlin version.

```
The StartParameter.isConfigurationCacheRequested property has been deprecated. This is scheduled to be removed in Gradle 10.0. Please use 'configurationCache.requested' property on 'BuildFeatures' service instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14/userguide/upgrading_version_8.html#deprecated_startparameter_is_configuration_cache_requested
Internal API DefaultArtifactPublicationSet.addCandidate(PublishArtifact) has been deprecated. This is scheduled to be removed in Gradle 9.0. Add the artifact as a direct dependency of the assemble task instead.
```

### Changelog

Wasn't sure this warranted changelog entries. I didn't find any others like this before.

### Refs

Based on [#200 comment 2900842100](https://github.com/catppuccin/jetbrains/issues/200#issuecomment-2900842100)
